### PR TITLE
Changing test so builds work when . is not in PERL5LIB path

### DIFF
--- a/t/02_api_test.t
+++ b/t/02_api_test.t
@@ -5,6 +5,7 @@ use 5.10.0;
 
 use Test::More;
 use Test::Exception;
+use lib '.';
 use t::Util qw/ slack set_mock_response /;
 
 subtest 'test' => sub {


### PR DESCRIPTION
Quick fix so that this module builds when user doens't have the current directory in the $PERL5LIB environment variable.