### PR TITLE
Correct parameter: name -> channel

### DIFF
--- a/lib/WebService/Slack/WebApi/Conversations.pm
+++ b/lib/WebService/Slack/WebApi/Conversations.pm
@@ -33,7 +33,7 @@ use WebService::Slack::WebApi::Generator (
         user    => 'Str',
     },
     join => {
-        name => 'Str',
+        channel => 'Str',
     },
     kick => {
         channel => 'Str',


### PR DESCRIPTION
Correct parameter for API conversations.join: name -> channel

https://api.slack.com/methods/conversations.join