### PR TITLE
Fix the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ WebService::Slack::WebApi - a simple wrapper for Slack Web API
     my $slack = WebService::Slack::WebApi->new(token => 'access token');
 
     # getting channel's descriptions
-    my $channels = $slack->channels->list;
+    my $channels = $slack->conversations->list;
 
     # posting message to specified channel and getting message description
     my $posted_message = $slack->chat->post_message(

--- a/lib/WebService/Slack/WebApi.pm
+++ b/lib/WebService/Slack/WebApi.pm
@@ -51,7 +51,7 @@ WebService::Slack::WebApi - a simple wrapper for Slack Web API
     my $slack = WebService::Slack::WebApi->new(token => 'access token');
 
     # getting channel's descriptions
-    my $channels = $slack->channels->list;
+    my $channels = $slack->conversations->list;
 
     # posting message to specified channel and getting message description
     my $posted_message = $slack->chat->post_message(


### PR DESCRIPTION
Replaced the deprecated "channels.list" method in the README with "conversations.list".
https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api