### PR TITLE
Change Dependency from JSON::XS to JSON

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -7,9 +7,10 @@ requires 'Data::Validator';
 requires 'Exception::Tiny';
 requires 'HTTP::AnyUA';
 requires 'IO::Socket::SSL';
-requires 'JSON::XS';
+requires 'JSON';
 
 recommends 'Furl';
+recommends 'JSON::XS';
 
 on 'test' => sub {
     requires 'Test::More';

--- a/lib/WebService/Slack/WebApi/Chat.pm
+++ b/lib/WebService/Slack/WebApi/Chat.pm
@@ -6,7 +6,7 @@ use feature qw/state/;
 
 use parent 'WebService::Slack::WebApi::Base';
 
-use JSON::XS;
+use JSON;
 use WebService::Slack::WebApi::Generator (
     delete => {
         channel => 'Str',

--- a/lib/WebService/Slack/WebApi/Client.pm
+++ b/lib/WebService/Slack/WebApi/Client.pm
@@ -4,7 +4,7 @@ use warnings;
 use utf8;
 
 use HTTP::AnyUA;
-use JSON::XS;
+use JSON;
 use WebService::Slack::WebApi::Exception;
 
 use Class::Accessor::Lite::Lazy (

--- a/lib/WebService/Slack/WebApi/Dialog.pm
+++ b/lib/WebService/Slack/WebApi/Dialog.pm
@@ -6,7 +6,7 @@ use feature qw/state/;
 
 use parent 'WebService::Slack::WebApi::Base';
 
-use JSON::XS;
+use JSON;
 
 sub open {
   state $rule = Data::Validator->new(

--- a/lib/WebService/Slack/WebApi/Users/Profile.pm
+++ b/lib/WebService/Slack/WebApi/Users/Profile.pm
@@ -6,7 +6,7 @@ use feature qw/state/;
 
 use parent 'WebService::Slack::WebApi::Base';
 
-use JSON::XS;
+use JSON;
 
 use WebService::Slack::WebApi::Generator (
     get => {

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -4,7 +4,7 @@ use warnings;
 use utf8;
 use feature qw/state/;
 
-use JSON::XS;
+use JSON;
 use Exporter qw/ import /;
 
 use WebService::Slack::WebApi;


### PR DESCRIPTION
JSON::XS depends on libc6, the GNU C Library, a binary which must be compiled.
JSON on the other hand selects the best available implementation:

    This module is a thin wrapper for JSON::XS-compatible modules with a few additional features.
    All the backend modules convert a Perl data structure to a JSON text and vice versa.
    This module uses JSON::XS by default, and when JSON::XS is not available, falls back on JSON::PP,
    which is in the Perl core since 5.14. If JSON::PP is not available either, this module then falls back on
    JSON::backportPP (which is actually JSON::PP in a different .pm file) bundled in the same distribution
    as this module. You can also explicitly specify to use Cpanel::JSON::XS, a fork of JSON::XS by Reini Urban.

https://metacpan.org/pod/JSON#DESCRIPTION

Signed-off-by: Mikko Johannes Koivunalho <mikko.koivunalho@iki.fi>