### PR TITLE
API conversations.open param channel is optional

### DIFF
--- a/lib/WebService/Slack/WebApi/Conversations.pm
+++ b/lib/WebService/Slack/WebApi/Conversations.pm
@@ -54,7 +54,7 @@ use WebService::Slack::WebApi::Generator (
         limit   => { isa => 'Int',  optional => 1 },
     },
     open => {
-        channel   => 'Str',
+        channel   => { isa => 'Str',  optional => 1 },
         return_im => { isa => 'Bool', optional => 1 },
         users     => { isa => 'Str',  optional => 1 },
     },


### PR DESCRIPTION
Issue: https://github.com/mihyaeru21/p5-WebService-Slack-WebApi/issues/42
    
[API conversations.open](https://api.slack.com/methods/conversations.open)

Signed-off-by: Mikko Johannes Koivunalho <mikko.koivunalho@iki.fi>