### PR TITLE
Use HTTP Auth header to authenticate

### DIFF
--- a/lib/WebService/Slack/WebApi/Client.pm
+++ b/lib/WebService/Slack/WebApi/Client.pm
@@ -48,12 +48,26 @@ sub base_url {
 sub request {
     my ($self, $path, $params) = @_;
 
+    my %headers;
+    if( $self->token && $params->{'http_auth'} ) {
+        my $msg = 'Illegal parameters. You have defined \'token\' but the '
+                . ' method you are using defines its own HTTP Authorization header.';
+        WebService::Slack::WebApi::Exception::IllegalParameters->throw(
+            message  => $msg,
+        );
+    }
+    if( $self->token ) {
+        $headers{ 'Authorization' } = 'Bearer ' . $self->token;
+    } elsif( $params->{'http_auth'} ) {
+        $headers{ 'Authorization' } = $params->{'http_auth'};
+    }
+    my %options = ( headers => \%headers );
     my $response = $self->ua->post_form(
         $self->base_url . $path,
         [
-            $self->token ? (token => $self->token) : (),
             %{ $params },
         ],
+        \%options,
     );
     return decode_json $response->{content} if $response->{success};
 

--- a/lib/WebService/Slack/WebApi/Oauth/V2.pm
+++ b/lib/WebService/Slack/WebApi/Oauth/V2.pm
@@ -4,21 +4,36 @@ use warnings;
 use utf8;
 use feature qw/ state /;
 
+use MIME::Base64 qw/ encode_base64 /;
+
 use parent 'WebService::Slack::WebApi::Base';
 
 # override
 sub base_name { 'oauth.v2' }
 
 sub access {
+    # Attn. client_id and client_secret are optional parameters for Slack
+    # because Slack makes it possible to authenticate either
+    # by using them or by setting an HTTP Auth header.
+    # https://api.slack.com/methods/oauth.v2.access
+    # But here we make the parameters mandatory because
+    # they are needed to call this method in any case.
     state $rule = Data::Validator->new(
         code          => 'Str',
-        client_id     => { isa => 'Str', optional => 1 },
-        client_secret => { isa => 'Str', optional => 1 },
+        client_id     => { isa => 'Str', optional => 0 },
+        client_secret => { isa => 'Str', optional => 0 },
         redirect_uri  => { isa => 'Str', optional => 1 },
     )->with('Method');
     my ($self, $args) = $rule->validate(@_);
 
-    return $self->request('access', { %$args });
+    my $t = encode_base64( $args->{'client_id'} . q{:} . $args->{'client_secret'}, q{} );
+    my $basic_auth = 'Basic ' . $t;
+    return $self->request('access', {
+            code => $args->{'code'},
+            redirect_uri => $args->{'redirect_uri'},
+            http_auth => $basic_auth,
+        }
+    );
 }
 
 1;

--- a/t/03_call_methods.t
+++ b/t/03_call_methods.t
@@ -4,8 +4,9 @@ use utf8;
 use feature qw/state/;
 
 use Test::More;
+use Test::Exception;
 use lib '.';
-use t::Util qw/ any_mocked_slack /;
+use t::Util qw/ any_mocked_slack mocked_slack_without_token /;
 
 my %tests = (
     auth => {
@@ -558,12 +559,25 @@ subtest 'users.profile' => sub {
 };
 
 subtest 'oauth.v2' => sub {
-    isa_ok $slack->oauth->v2->access(
+    throws_ok {
+        $slack->oauth->v2->access(
+            code          => 'ccdaa72ad',
+            client_id     => '4b39e9-752c4',
+            client_secret => '33fea0113f5b1',
+            redirect_uri  => 'http://example.com',
+        );
+    } 'WebService::Slack::WebApi::Exception::IllegalParameters',
+    'Illegal parameters: defined token when calling oath.v2.access';
+
+    my $sl = mocked_slack_without_token();
+    isa_ok $sl->oauth->v2->access(
         code          => 'ccdaa72ad',
         client_id     => '4b39e9-752c4',
         client_secret => '33fea0113f5b1',
         redirect_uri  => 'http://example.com',
     ), 'HASH';
+
+    done_testing;
 };
 
 done_testing;

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -9,10 +9,10 @@ use Exporter qw/ import /;
 
 use WebService::Slack::WebApi;
 
-our @EXPORT_OK = qw/ mocked_slack any_mocked_slack /;
+our @EXPORT_OK = qw/ mocked_slack any_mocked_slack mocked_slack_without_token /;
 
 sub mocked_slack {
-    my ($content, $is_success) = @_;
+    my ($content, $is_success, $no_token) = @_;
 
     # mock ua for HTTP::AnyUA
     # don't use with real HTTP::Tiny
@@ -22,10 +22,14 @@ sub mocked_slack {
     }, 'HTTP::Tiny';
     sub HTTP::Tiny::request { shift }
 
+    if(defined $no_token && $no_token) {
+        return WebService::Slack::WebApi->new(ua => $ua);
+    }
     return WebService::Slack::WebApi->new(token => 'a', ua => $ua);
 }
 
 sub any_mocked_slack { mocked_slack +{hoge => 'fuga'}, 1 }
+sub mocked_slack_without_token { mocked_slack +{hoge => 'fuga'}, 1, 1 }
 
 1;
 


### PR DESCRIPTION
https://api.slack.com/web#authentication
Use HTTP header Authorization. Slack document seems to be saying we should use the header in every API call.

https://github.com/mihyaeru21/p5-WebService-Slack-WebApi/issues/39

Use HTTP Auth header to authenticate
Use HTTP Auth header to authenticate in oauth.v2.access 