### PR TITLE
Add user.conversations and conversations.mark endpoints

### DIFF
--- a/lib/WebService/Slack/WebApi/Conversations.pm
+++ b/lib/WebService/Slack/WebApi/Conversations.pm
@@ -48,6 +48,10 @@ use WebService::Slack::WebApi::Generator (
         limit            => { isa => 'Int',  optional => 1 },
         types            => { isa => 'Str',  optional => 1 }, 
     },
+    mark => {
+        channel => 'Str',
+        ts      => 'Str',
+    },
     members => {
         channel => 'Str',
         cursor  => { isa => 'Str',  optional => 1 },

--- a/lib/WebService/Slack/WebApi/Users.pm
+++ b/lib/WebService/Slack/WebApi/Users.pm
@@ -12,6 +12,15 @@ use Class::Accessor::Lite::Lazy (
 );
 
 use WebService::Slack::WebApi::Generator (
+    conversations => {
+        cursor           => { isa => 'Str',  optional => 1 },
+        exclude_archived => { isa => 'Bool', optional => 1 },
+        limit            => { isa => 'Int',  optional => 1 },
+        presence         => { isa => 'Bool', optional => 1 },
+        team_id          => { isa => 'Str',  optional => 1 },
+        types            => { isa => 'Str',  optional => 1 },
+        user             => { isa => 'Str',  optional => 1 },
+    },
     delete_photo => +{},
     get_presence => {
         user => 'Str',

--- a/t/03_call_methods.t
+++ b/t/03_call_methods.t
@@ -527,6 +527,12 @@ my %tests = (
         },
     },
     users => {
+        conversations => {
+            cursor           => 'dXNlcjpVMDYxTkZUVDI=',
+            exclude_archived => 1,
+            exclude_members  => 1,
+            limit            => 20,
+        },
         delete_photo => +{},
         get_presence => {
             user => 'hoge',

--- a/t/03_call_methods.t
+++ b/t/03_call_methods.t
@@ -122,6 +122,10 @@ my %tests = (
             limit            => 20,
             types            => 'public_channel,private_channel'
         },
+        mark => {
+            channel => 'hoge',
+            ts      => '1234567890.123456',
+        },
         members => {
             channel => 'hoge',
             cursor  => 'dXNlcjpVMDYxTkZUVDI=',


### PR DESCRIPTION
This should resolve #50 and #51 by adding these new endpoints that replace some of [the ones that were deprecated](https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api).  I didn't need the other new conversations endpoints, so I didn't add those.

I also didn't remove the old deprecated methods, even though they no longer work.

There is now [an OpenAPI v2 specification for the web API](https://api.slack.com/web#spec).  Not sure if converting to generate the Client from that is worthwhile.