### PR TITLE
Update META.json

### DIFF
--- a/META.json
+++ b/META.json
@@ -52,7 +52,6 @@
             "Data::Validator" : "0",
             "Exception::Tiny" : "0",
             "HTTP::AnyUA" : "0",
-            "IO::Socket::SSL" : "0",
             "JSON" : "0",
             "perl" : "5.010"
          }


### PR DESCRIPTION
Remove  dependency to IO::Socket::SSL.

We have dependency to HTTP::AnyUA (and recommendation to Furl), so we shouldn't need it.
Or do we?

In fact, just to ask, why do we have META.json committed in the repo? Minilla generates it for us. (Same applies to Build.PL)