### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,19 +14,17 @@ jobs:
       fail-fast: false
       matrix:
         perl:
-          - '5.10'
-          - '5.28'
-          - '5.30'
-          - '5.32'
+          - '5.12'
+          - '5.40'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup perl
         uses: shogo82148/actions-setup-perl@v1
         with:
           perl-version: ${{ matrix.perl }}
       - run: perl -V
       - name: Cache local files
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./local
           key: ${{ runner.os }}-perl-${{ matrix.perl }}-${{ hashFiles('./cpanfile.snapshot') }}


### PR DESCRIPTION
> Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
